### PR TITLE
Add merge

### DIFF
--- a/bag_tools/CMakeLists.txt
+++ b/bag_tools/CMakeLists.txt
@@ -31,25 +31,26 @@ install(TARGETS
 )
 
 install(PROGRAMS
-    scripts/stereo_sequence_publisher.py
-    scripts/replace_msg_time_with_hdr.py
-    scripts/remove_tf.py
-    scripts/transform_tf.py
-    scripts/make_video.py
-    scripts/image_sequence_publisher.py
-    scripts/gps_to_std_gt.py
-    scripts/extract_topics.py
-    scripts/cut.py
+    scripts/add_header_time_offset.py
+    scripts/bag_add_time_offset.py
+    scripts/batch_process.py
+    scripts/camera_info_parser.py
+    scripts/change_camera_info.py
+    scripts/change_frame_id.py
+    scripts/change_topics.py
     scripts/check_delay.py
     scripts/check_drop.py
-    scripts/change_topics.py
-    scripts/change_frame_id.py
-    scripts/change_camera_info.py
-    scripts/camera_info_parser.py
-    scripts/batch_process.py
-    scripts/bag_add_time_offset.py
-    scripts/add_header_time_offset.py
+    scripts/cut.py
+    scripts/extract_topics.py
+    scripts/gps_to_std_gt.py
+    scripts/image_sequence_publisher.py
+    scripts/make_video.py
+    scripts/merge.py
     scripts/plot.py
+    scripts/remove_tf.py
+    scripts/replace_msg_time_with_hdr.py
+    scripts/stereo_sequence_publisher.py
+    scripts/transform_tf.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/bag_tools/scripts/merge.py
+++ b/bag_tools/scripts/merge.py
@@ -34,7 +34,7 @@ import rosbag
 
 import argparse
 
-def merge(inbags, outbag='output.bag', topics=None, raw=True):
+def merge(inbags, outbag='output.bag', topics=None, exclude_topics=[], raw=True):
   # Open output bag file:
   try:
     out = rosbag.Bag(outbag, 'a')
@@ -48,7 +48,8 @@ def merge(inbags, outbag='output.bag', topics=None, raw=True):
     try:
       rospy.loginfo('   Processing input bagfile: %s', inbag)
       for topic, msg, t in rosbag.Bag(inbag, 'r').read_messages(topics=topics, raw=raw):
-        out.write(topic, msg, t, raw=raw)
+        if topic not in args.exclude_topics:
+          out.write(topic, msg, t, raw=raw)
     except IOError as e:
       rospy.logerr('Failed to open input bag file %s!: %s' % (inbag, e.message))
       rospy.signal_shutdown('Failed to open input bag file %s!: %s' % (inbag, e.message))
@@ -65,10 +66,11 @@ if __name__ == "__main__":
   parser.add_argument('inbag', help='input bagfile(s)', nargs='+')
   parser.add_argument('--output', help='output bag file', default='output.bag')
   parser.add_argument('--topics', help='topics to merge from the input bag files', nargs='+', default=None)
+  parser.add_argument('--exclude_topics', help='topics not to merge from the input bag files', nargs='+', default=[])
   args = parser.parse_args()
 
   try:
-    merge(args.inbag, args.output, args.topics)
+    merge(args.inbag, args.output, args.topics, args.exclude_topics)
   except Exception, e:
     import traceback
     traceback.print_exc()

--- a/bag_tools/scripts/merge.py
+++ b/bag_tools/scripts/merge.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python
+"""
+Copyright (c) 2015,
+Enrique Fernandez Perdomo
+Clearpath Robotics, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Systems, Robotics and Vision Group, University of 
+      the Balearican Islands nor the names of its contributors may be used to 
+      endorse or promote products derived from this software without specific 
+      prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+import rospy
+import rosbag
+
+import argparse
+
+def merge(inbags, outbag='output.bag', topics=None, raw=True):
+  # Open output bag file:
+  try:
+    out = rosbag.Bag(outbag, 'a')
+  except IOError as e:
+    rospy.logerr('Failed to open output bag file %s!: %s' % (outbag, e.message))
+    rospy.signal_shutdown('Failed to open output bag file %s!: %s' % (outbag, e.message))
+    return
+
+  # Write the messages from the input bag files into the output one:
+  for inbag in inbags:
+    try:
+      rospy.loginfo('   Processing input bagfile: %s', inbag)
+      for topic, msg, t in rosbag.Bag(inbag, 'r').read_messages(topics=topics, raw=raw):
+        out.write(topic, msg, t, raw=raw)
+    except IOError as e:
+      rospy.logerr('Failed to open input bag file %s!: %s' % (inbag, e.message))
+      rospy.signal_shutdown('Failed to open input bag file %s!: %s' % (inbag, e.message))
+      return
+
+  out.close()
+
+
+if __name__ == "__main__":
+  rospy.init_node('merge', anonymous=True)
+
+  parser = argparse.ArgumentParser(
+      description='Merge multiple bag files into a single one.')
+  parser.add_argument('inbag', help='input bagfile(s)', nargs='+')
+  parser.add_argument('--output', help='output bag file', default='output.bag')
+  parser.add_argument('--topics', help='topics to merge from the input bag files', nargs='+', default=None)
+  args = parser.parse_args()
+
+  try:
+    merge(args.inbag, args.output, args.topics)
+  except Exception, e:
+    import traceback
+    traceback.print_exc()


### PR DESCRIPTION
Python script to merge multiple bag files into a single one.

The bag time of each time is respected so the messages are played at the proper time. Note that `rosbag play` already does the same if multiple bag files are provided. However, sometimes is better to have a single file rather than many.
