### PR TITLE
Fix plot on background

### DIFF
--- a/bag_tools/scripts/plot.py
+++ b/bag_tools/scripts/plot.py
@@ -46,6 +46,10 @@ import string
 
 from operator import itemgetter
 
+# Workaround to avoid issues with X11 rendering when running on background:
+import matplotlib as mpl
+mpl.use('Agg')
+
 import matplotlib.pyplot as plt
 
 

--- a/bag_tools/scripts/plot.py
+++ b/bag_tools/scripts/plot.py
@@ -427,6 +427,8 @@ class BagTopicPlotter:
             rospy.logwarn("Does NOT support multiple bags yet! Only first bag will be used.")
         bag = self._bags[0]
 
+        rospy.loginfo("Processing %s ..." % bag)
+
         # Retrieve/Expand plottable topic fields:
         plottable_topics = []
         for topic in topics:


### PR DESCRIPTION
Workaround to avoid issues with X11 rendering when running on background.

```
X11 connection rejected because of wrong authentication.
```
