### PR TITLE
Remove signals from boost component to work with boost 71

### DIFF
--- a/bag_tools/CMakeLists.txt
+++ b/bag_tools/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(bag_tools)
 
 find_package(catkin REQUIRED COMPONENTS rospy rosbag sensor_msgs cv_bridge message_filters image_proc stereo_image_proc image_geometry camera_calibration_parsers)
-find_package(Boost REQUIRED COMPONENTS signals thread)
+find_package(Boost REQUIRED COMPONENTS thread)
 find_package(OpenCV REQUIRED)
 find_package(console_bridge REQUIRED)
 


### PR DESCRIPTION
Remove signals from required Boost Component.

signals is no longer supported in boost 1.71